### PR TITLE
🗑️ chore: Remove obsolete metadata and keep files

### DIFF
--- a/Document~.meta
+++ b/Document~.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b226121ee4037594990be4b58926f6e7
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
This commit deletes the `Document~.meta` and `.keep` files from the repository. The removal of these files indicates that they are no longer needed for the project, streamlining the file structure and reducing clutter. Ensure to verify any dependencies or references that may have relied on these files.